### PR TITLE
Change malloc to calloc and remove memset

### DIFF
--- a/frotz/src/dumb/dumb_output.c
+++ b/frotz/src/dumb/dumb_output.c
@@ -539,9 +539,8 @@ void dumb_init_output(void)
 	show_line_types = h_version > 3;
 
     screen_data = malloc(screen_cells * sizeof(cell));
-    screen_changes = malloc(screen_cells);
+    screen_changes = calloc(screen_cells, sizeof(char));
     os_erase_area(1, 1, h_screen_rows, h_screen_cols, -2);
-    memset(screen_changes, 0, screen_cells);
 }
 
 char* dumb_get_screen(void) {


### PR DESCRIPTION
calloc() zero-initializes the buffer, so it is not necessary call memset() after.