### PR TITLE
`textworld_clean_observation` is pruning one character too many.

### DIFF
--- a/frotz/src/games/textworld.c
+++ b/frotz/src/games/textworld.c
@@ -70,7 +70,7 @@ char* textworld_clean_observation(char* obs) {
   parse_score_and_move_count(obs);
   pch = strrchr(obs, '>');
   if (pch != NULL) {
-    *(pch-2) = '\0';
+    *(pch-1) = '\0';
   }
   return obs+1;
 }

--- a/tests/test_textworld_games.py
+++ b/tests/test_textworld_games.py
@@ -78,5 +78,6 @@ def test_cleaning_observation():
     like it's a counter. You see a red apple and a knife on the counter. You make out a stove. But the thing hasn't got anything on
     it.
 
+
     """)
     assert [line.strip() for line in state.split("\n")] == [line.strip() for line in EXPECTED.split("\n")]


### PR DESCRIPTION
This PR fixes an issue within the function `textworld_clean_observation` where the last character of the observation string is always pruned.

@mhauskn if you can bump Jericho's version number that would be great. This fix is needed for https://github.com/microsoft/TextWorld/pull/185. Thanks.