### PR TITLE
Disable word wrapping in frotz.

### DIFF
--- a/frotz/src/common/screen.c
+++ b/frotz/src/common/screen.c
@@ -321,39 +321,39 @@ void screen_word (const zchar *s)
     if (*s == ZC_INDENT && cwp->x_cursor != cwp->left + 1)
 	screen_char (*s++);
 
-    if (units_left () < (width = os_string_width (s))) {
+// Disable word wrapping.
+//     if (units_left () < (width = os_string_width (s))) {
 
-	if (!enable_wrapping) {
+// 	if (!enable_wrapping) {
+// 	    zchar c;
 
-	    zchar c;
+// 	    while ((c = *s++) != 0)
 
-	    while ((c = *s++) != 0)
+// 		if (c == ZC_NEW_FONT || c == ZC_NEW_STYLE) {
 
-		if (c == ZC_NEW_FONT || c == ZC_NEW_STYLE) {
+// 		    int arg = (int) *s++;
 
-		    int arg = (int) *s++;
+// 		    if (c == ZC_NEW_FONT)
+// 			os_set_font (arg);
+// 		    if (c == ZC_NEW_STYLE)
+// 			os_set_text_style (arg);
 
-		    if (c == ZC_NEW_FONT)
-			os_set_font (arg);
-		    if (c == ZC_NEW_STYLE)
-			os_set_text_style (arg);
+// 		} else screen_char (c);
 
-		} else screen_char (c);
+// 	    return;
 
-	    return;
+// 	}
 
-	}
+// 	if (*s == ' ' || *s == ZC_INDENT || *s == ZC_GAP)
+// 	    width = os_string_width (++s);
 
-	if (*s == ' ' || *s == ZC_INDENT || *s == ZC_GAP)
-	    width = os_string_width (++s);
+// #ifdef AMIGA
+// 	if (cwin == 0) Justifiable ();
+// #endif
 
-#ifdef AMIGA
-	if (cwin == 0) Justifiable ();
-#endif
+// 	screen_new_line ();
 
-	screen_new_line ();
-
-    }
+//     }
 
     os_display_string (s); cwp->x_cursor += width;
 

--- a/tests/test_textworld_games.py
+++ b/tests/test_textworld_games.py
@@ -69,14 +69,9 @@ def test_cleaning_observation():
     You are hungry! Let's cook a delicious meal. Check the cookbook in the kitchen for the recipe. Once done, enjoy your meal!
 
     -= Kitchen =-
-    You arrive in a kitchen. An ordinary kind of place. The room seems oddly familiar, as though it were only superficially
-    different from the other rooms in the building.
+    You arrive in a kitchen. An ordinary kind of place. The room seems oddly familiar, as though it were only superficially different from the other rooms in the building.
 
-    You lean against the wall, inadvertently pressing a secret button. The wall opens up to reveal a fridge. The fridge is empty,
-    what a horrible day! You make out a closed oven. You lean against the wall, inadvertently pressing a secret button. The wall
-    opens up to reveal a table. You see a cookbook on the table. Now that's what I call TextWorld! What's that over there? It looks
-    like it's a counter. You see a red apple and a knife on the counter. You make out a stove. But the thing hasn't got anything on
-    it.
+    You lean against the wall, inadvertently pressing a secret button. The wall opens up to reveal a fridge. The fridge is empty, what a horrible day! You make out a closed oven. You lean against the wall, inadvertently pressing a secret button. The wall opens up to reveal a table. You see a cookbook on the table. Now that's what I call TextWorld! What's that over there? It looks like it's a counter. You see a red apple and a knife on the counter. You make out a stove. But the thing hasn't got anything on it.
 
 
     """)


### PR DESCRIPTION
At the moment, long sentences are causing word wrapping. This PR modifies the frotz internal to skip word wrapping. 

~~This PR increases the "screen width".~~
~~I don't know if there's a better solution but I think @mhauskn did the same for screen height?~~