### PR TITLE
Fixing undefined variable in load_bindings

### DIFF
--- a/jericho/jericho.py
+++ b/jericho/jericho.py
@@ -241,7 +241,7 @@ frotz_lib.ztools_cleanup.restype = None
 
 def load_bindings(rom):
     """
-    Loads information pertaining to the current game. Resturns a dictionary
+    Loads information pertaining to the current game. Returns a dictionary
     with the following keys:
 
     - `name`: Name of the game. E.g. `zork1`
@@ -276,12 +276,10 @@ def load_bindings(rom):
     """
     rom = os.path.basename(rom)
     for k, v in defines.BINDINGS_DICT.items():
-        if v['rom'] == rom:
+        if k == rom or v['rom'] == rom:
             return v
-    if rom in defines.BINDINGS_DICT:
-        return bindings[rom]
-    else:
-        raise ValueError('No bindings available for rom {}'.format(self.story_file))
+
+    raise ValueError('No bindings available for rom {}'.format(rom))
 
 
 class UnsupportedGameWarning(UserWarning):

--- a/tests/test_jericho.py
+++ b/tests/test_jericho.py
@@ -1,0 +1,13 @@
+import os
+import unittest
+from os.path import join as pjoin
+
+import jericho
+
+
+class TestJericho(unittest.TestCase):
+    def test_load_bindings(self):
+        self.assertRaises(ValueError, jericho.load_bindings, "")
+        data1 = jericho.load_bindings("905")
+        data2 = jericho.load_bindings("905.z5")
+        assert data1 == data2


### PR DESCRIPTION
This PR fixes the "undefined variable" error when calling `jericho.load_bindings("zork1")` as shown in the function's example. I also added some unit tests for that function.