### PR TITLE
Fix memory leaks

### DIFF
--- a/frotz/src/common/fastmem.c
+++ b/frotz/src/common/fastmem.c
@@ -558,6 +558,9 @@ void reset_memory (void)
 	fclose (story_fp);
     story_fp = NULL;
 
+	if (stf_buff) { free(stf_buff); }
+	stf_buff = NULL;
+
     if (undo_mem) {
 	free_undo (undo_count);
 	free (undo_mem);

--- a/frotz/src/dumb/dumb_output.c
+++ b/frotz/src/dumb/dumb_output.c
@@ -555,3 +555,14 @@ char* dumb_get_screen(void) {
 void dumb_clear_screen(void) {
   screen_buffer_ptr = screen_buffer;
 }
+
+void dumb_free(void) {
+	if (screen_data) {
+      free(screen_data);
+	  screen_data = NULL;
+    }
+    if (screen_changes) {
+      free(screen_changes);
+	  screen_changes = NULL;
+    }
+}

--- a/frotz/src/interface/frotz_interface.c
+++ b/frotz/src/interface/frotz_interface.c
@@ -54,6 +54,7 @@ extern void insert_obj(zword obj1, zword obj2);
 extern void seed_random (int value);
 extern void set_random_seed (int seed);
 extern void sum(FILE*, char*);
+extern void dumb_free();
 
 zbyte next_opcode;
 int desired_seed = 0;
@@ -295,6 +296,7 @@ void load_rom_bindings(char *story_file) {
 
 void shutdown() {
   reset_memory();
+  dumb_free();
 }
 
 // Save the state of the game into a string buffer

--- a/jericho/jericho.py
+++ b/jericho/jericho.py
@@ -28,6 +28,10 @@ from pkg_resources import Requirement, resource_filename
 JERICHO_PATH = resource_filename(Requirement.parse('jericho'), 'jericho')
 FROTZ_LIB_PATH = os.path.join(JERICHO_PATH, 'libfrotz.so')
 
+# Function to unload a shared library.
+dlclose_func = CDLL(None).dlclose  # This WON'T work on Win
+dlclose_func.argtypes = [c_void_p]
+
 
 class ZObject(Structure):
     """
@@ -326,6 +330,7 @@ class FrotzEnv():
     def __del__(self):
         if hasattr(self, 'frotz_lib'):
             self.frotz_lib.shutdown()
+            dlclose_func(self.frotz_lib._handle)
 
     def get_dictionary(self):
         ''' Returns a list of :class:`jericho.DictionaryWord` words recognized\

--- a/tests/test_jericho.py
+++ b/tests/test_jericho.py
@@ -20,8 +20,8 @@ def test_multiple_instances():
     gamefile2 = pjoin(DATA_PATH, "tw-game.z8")
 
     # Make sure both frotz_lib have different handles.
-    env1 = jericho.FrotzEnv(pjoin(DATA_PATH, gamefile1))
-    env2 = jericho.FrotzEnv(pjoin(DATA_PATH, gamefile2))
+    env1 = jericho.FrotzEnv(gamefile1)
+    env2 = jericho.FrotzEnv(gamefile2)
     assert env1.frotz_lib._handle != env2.frotz_lib._handle
 
     # Test we can play two different games in parallel.
@@ -37,3 +37,41 @@ def test_multiple_instances():
     state2, _, _, _ = env2.step("examine me")
     env2.close()
     assert "As good-looking as ever." in state2
+
+
+def test_for_memory_leaks():
+    # Make sure we don't have severe memory leaks.
+
+    def _get_mem():
+        import resource
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    gamefile1 = pjoin(DATA_PATH, "905.z5")
+    env1 = jericho.FrotzEnv(gamefile1)
+    env1.reset()
+    del env1
+
+    mem_start = _get_mem()
+    print('Memory usage: {:.1f}MB'.format(mem_start / 1024))
+    for _ in range(1000):
+        # Make sure we don't have memory leak.
+        env1 = jericho.FrotzEnv(gamefile1)
+        env1.reset()
+        del env1
+
+    mem_mid = _get_mem()
+    print('Memory usage: {:.1f}MB ({:+.1f}MB)'.format(
+           mem_mid / 1024, (mem_mid-mem_start) / 1024 ))
+
+    for _ in range(1000):
+        env1 = jericho.FrotzEnv(gamefile1)
+        env1.reset()
+        del env1
+
+    mem_end = _get_mem()
+    print('Memory usage: {:.1f}MB ({:+.1f}MB)'.format(
+          mem_end / 1024, (mem_end-mem_mid) / 1024))
+
+    # Less than 1MB memory leak per 1000 load/unload cycles.
+    assert (mem_mid - mem_start) < 1024*1024
+    assert (mem_end - mem_mid) < 1024*1024


### PR DESCRIPTION
This PR makes sure to deallocate the story buffer and the dumb screen buffers. I've added a test checking that memleaks are less than 1MB per 1000 load/unload cycles.

Here are some numbers to give you an idea of the scale of the current memleaks. Before the proposed fix
```
Memory usage: 40.4MB
# Load/unload 1000 FrotzEnv
Memory usage: 603.5MB (+563.0MB)
# Load/unload 1000 FrotzEnv
Memory usage: 1167.4MB (+563.9MB)
```
and now with the fix
```
Memory usage: 40.4MB
# Load/unload 1000 FrotzEnv
Memory usage: 40.8MB (+0.4MB)
# Load/unload 1000 FrotzEnv
Memory usage: 41.1MB (+0.4MB)
```