### PR TITLE
Make FrotzEnv copiable

### DIFF
--- a/frotz/src/common/random.c
+++ b/frotz/src/common/random.c
@@ -27,6 +27,37 @@ static int counter = 0;
 
 
 /*
+ * Functions to get the state of the random number generator.
+ *
+ */
+
+long getRngA() {
+  return A;
+}
+
+int getRngInterval() {
+  return interval;
+}
+
+int getRngCounter() {
+  return counter;
+}
+
+
+/*
+ * set_rng
+ *
+ * Set the state of the random number generator.
+ *
+ */
+void setRng(long p_A, int p_interval, int p_counter) {
+    A = p_A;
+    interval = p_interval;
+    counter = p_counter;
+}
+
+
+/*
  * seed_random
  *
  * Set the seed value for the random number generator.

--- a/frotz/src/dumb/dumb_init.c
+++ b/frotz/src/dumb/dumb_init.c
@@ -178,26 +178,37 @@ void free_setup()
 {
     if (f_setup.story_file != NULL)
         free(f_setup.story_file);
+    f_setup.story_file = NULL;
     if (f_setup.story_name != NULL)
         free(f_setup.story_name);
+    f_setup.story_name = NULL;
     if (f_setup.story_base != NULL)
         free(f_setup.story_base);
+    f_setup.story_base = NULL;
     if (f_setup.script_name != NULL)
         free(f_setup.script_name);
+    f_setup.script_name = NULL;
     if (f_setup.command_name != NULL)
         free(f_setup.command_name);
+    f_setup.command_name = NULL;
     if (f_setup.save_name != NULL)
         free(f_setup.save_name);
+    f_setup.save_name = NULL;
     if (f_setup.tmp_save_name != NULL)
         free(f_setup.tmp_save_name);
+    f_setup.tmp_save_name = NULL;
     if (f_setup.aux_name != NULL)
         free(f_setup.aux_name);
+    f_setup.aux_name = NULL;
     if (f_setup.story_path != NULL)
         free(f_setup.story_path);
+    f_setup.story_path = NULL;
     if (f_setup.zcode_path != NULL)
         free(f_setup.zcode_path);
+    f_setup.zcode_path = NULL;
     if (f_setup.restricted_path != NULL)
         free(f_setup.restricted_path);
+    f_setup.restricted_path = NULL;
 }
 
 void load_story(char *s)

--- a/frotz/src/interface/frotz_interface.c
+++ b/frotz/src/interface/frotz_interface.c
@@ -302,6 +302,7 @@ void load_rom_bindings(char *story_file) {
 void shutdown() {
   reset_memory();
   dumb_free();
+  free_setup();
 }
 
 // Save the state of the game into a string buffer

--- a/frotz/src/interface/frotz_interface.c
+++ b/frotz/src/interface/frotz_interface.c
@@ -360,6 +360,10 @@ void getRAM(unsigned char *ram) {
   memcpy(ram, zmp, h_dynamic_size);
 }
 
+void setRAM(unsigned char *ram) {
+  memcpy(zmp, ram, h_dynamic_size);
+}
+
 int zmp_diff(int addr) {
   if (zmp[addr] != prev_zmp[addr]) {
     return 1;
@@ -381,16 +385,52 @@ int getPC() {
   return pcp - zmp;
 }
 
+void setPC(int v) {
+  pcp = zmp + v;
+}
+
+int getSP() {
+  return sp - stack;
+}
+
+void setSP(int v) {
+  sp = stack + v;
+}
+
+int getFP() {
+  return fp - stack;
+}
+
+void setFP(int v) {
+  fp = stack + v;
+}
+
+int getFrameCount() {
+  return frame_count;
+}
+
+void setFrameCount(int count) {
+  frame_count = count;
+}
+
 int getStackSize() {
-  return STACK_SIZE;
+  return STACK_SIZE*sizeof(zword);
 }
 
 void getStack(unsigned char *s) {
   memcpy(s, stack, STACK_SIZE*sizeof(zword));
 }
 
+void setStack(unsigned char *s) {
+  memcpy(stack, s, STACK_SIZE*sizeof(zword));
+}
+
 void getZArgs(unsigned char *s) {
   memcpy(s, zargs, 8*sizeof(zword));
+}
+
+void setZArgs(unsigned char *s) {
+  memcpy(zargs, s, 8*sizeof(zword));
 }
 
 void get_world_diff(zword *objs, zword *dest) {

--- a/frotz/src/interface/frotz_interface.c
+++ b/frotz/src/interface/frotz_interface.c
@@ -56,6 +56,11 @@ extern void set_random_seed (int seed);
 extern void sum(FILE*, char*);
 extern void dumb_free();
 
+extern long getRngA();
+extern int getRngInterval();
+extern int getRngCounter();
+extern void setRng(long, int, int);
+
 zbyte next_opcode;
 int desired_seed = 0;
 int ROM_IDX = 0;

--- a/jericho/jericho.py
+++ b/jericho/jericho.py
@@ -257,6 +257,15 @@ def load_frotz_lib():
     frotz_lib.setFrameCount.argtypes = [c_int]
     frotz_lib.setFrameCount.restype = None
 
+    frotz_lib.getRngA.argtypes = []
+    frotz_lib.getRngA.restype = np.int64
+    frotz_lib.getRngInterval.argtypes = []
+    frotz_lib.getRngInterval.restype = int
+    frotz_lib.getRngCounter.argtypes = []
+    frotz_lib.getRngCounter.restype = int
+    frotz_lib.setRng.argtypes = [c_long, c_int, c_int]
+    frotz_lib.setRng.restype = None
+
     frotz_lib.getRAMSize.argtypes = []
     frotz_lib.getRAMSize.restype = int
     frotz_lib.getRAM.argtypes = [c_void_p]
@@ -520,14 +529,18 @@ class FrotzEnv():
         sp = self.frotz_lib.getSP()
         fp = self.frotz_lib.getFP()
         frame_count = self.frotz_lib.getFrameCount()
+        rng = self.frotz_lib.getRngA(), self.frotz_lib.getRngInterval(), self.frotz_lib.getRngCounter()
 
         env = FrotzEnv(self.story_file.decode(), seed=self.seed)
+
+        env.frotz_lib.setRng(*rng)
         env.frotz_lib.setRAM(as_ctypes(ram))
         env.frotz_lib.setStack(as_ctypes(stack))
         env.frotz_lib.setPC(pc)
         env.frotz_lib.setSP(sp)
         env.frotz_lib.setFP(fp)
         env.frotz_lib.setFrameCount(frame_count)
+
         return env
 
     def get_player_location(self):

--- a/tests/test_jericho.py
+++ b/tests/test_jericho.py
@@ -15,6 +15,7 @@ class TestJericho(unittest.TestCase):
         data2 = jericho.load_bindings("905.z5")
         assert data1 == data2
 
+
 def test_multiple_instances():
     gamefile1 = pjoin(DATA_PATH, "905.z5")
     gamefile2 = pjoin(DATA_PATH, "tw-game.z8")
@@ -75,3 +76,25 @@ def test_for_memory_leaks():
     # Less than 1MB memory leak per 1000 load/unload cycles.
     assert (mem_mid - mem_start) < 1024*1024
     assert (mem_end - mem_mid) < 1024*1024
+
+
+def test_copy():
+    gamefile1 = pjoin(DATA_PATH, "905.z5")
+    env1 = jericho.FrotzEnv(pjoin(DATA_PATH, gamefile1))
+    walkthrough = jericho.load_bindings("905")["walkthrough"]
+
+    for i, cmd in enumerate(walkthrough.split("/")):
+        env2 = env1.copy()
+        obs1, score1, done1, infos1 = env1.step(cmd)
+        obs2, score2, done2, infos2 = env2.step(cmd)
+
+        print(cmd)
+        print(obs1)
+
+        assert env1 != env2
+        assert env1.frotz_lib._handle != env2.frotz_lib._handle
+        assert env1.player_obj_num == env2.player_obj_num
+        assert obs1 == obs2
+        assert score1 == score2
+        assert done1 == done2
+        assert infos1 == infos2


### PR DESCRIPTION
This PR proposes a better way of saving the state of a game compared to `save_str/load_str`. With this PR one simply has to do
```python
import jericho
env = jericho.FrotzEnv("zork1.z5")
obs, info = env.reset()

fork = env.copy()
obs, _, _, _ = fork.step("open mailbox")
print(obs)  # Opening the small mailbox reveals a leaflet.
obs, _, _, _ = fork.step("open mailbox")
print(obs)  # It is already open.

obs, _, _, _ = env.step("open mailbox")
print(obs)  # Opening the small mailbox reveals a leaflet.
```