### PR TITLE
Add dedicated method to change seed

### DIFF
--- a/tests/test_jericho.py
+++ b/tests/test_jericho.py
@@ -80,7 +80,7 @@ def test_for_memory_leaks():
 def test_copy():
     rom = pjoin(DATA_PATH, "905.z5")
     env = jericho.FrotzEnv(rom)
-    env.reset(use_walkthrough_seed=True)
+    env.reset()
 
     walkthrough = env.get_walkthrough()
     expected = [env.step(act) for act in walkthrough]

--- a/tools/find_walkthrough.py
+++ b/tools/find_walkthrough.py
@@ -21,17 +21,15 @@ def parse_args():
 
 args = parse_args()
 
-bindings = jericho.load_bindings(args.filename)
-env = jericho.FrotzEnv(args.filename, seed=bindings['seed'])
-
 history = []
+env = jericho.FrotzEnv(args.filename)
 obs, info = env.reset()
 
 history.append(env.get_state())
 
 STEP_BY_STEP_WALKTRHOUGH = True
 
-walkthrough = bindings.get('walkthrough', '').split('/')
+walkthrough = env.get_walkthrough()
 if args.walkthrough:
     walkthrough = []
     for line in open(args.walkthrough):
@@ -73,15 +71,6 @@ while True:
         obs_list.append(obs)
         history.append(env.get_state())
         cpt += 1
-
-# while not done:
-#     print(obs)
-#     cmd = input("> ")
-#     if cmd == "DEBUG":
-#         from ipdb import set_trace; set_trace()
-
-#     commands.append(cmd)
-#     obs, rew, done, info = env.step(cmd)
 
 print()
 print("/".join(commands).replace('"', '\\"'))

--- a/tools/test_games.py
+++ b/tools/test_games.py
@@ -22,21 +22,20 @@ args = parse_args()
 filename_max_length = max(map(len, args.filenames))
 for filename in sorted(args.filenames):
     print(filename.ljust(filename_max_length), end=" ")
-    try:
-        bindings = jericho.load_bindings(filename)
-    except ValueError:
+
+    env = jericho.FrotzEnv(filename)
+    if not env.is_fully_supported:
         print(colored("SKIP\tUnsupported game", 'yellow'))
         continue
 
-    if "walkthrough" not in bindings:
+    if "walkthrough" not in env.bindings:
         print(colored("SKIP\tMissing walkthrough", 'yellow'))
         continue
 
-    env = jericho.FrotzEnv(filename, seed=bindings['seed'])
     env.reset()
 
-    walkthrough = bindings['walkthrough'].split('/')
-    for cmd in walkthrough:
+    #walkthrough = bindings['walkthrough'].split('/')
+    for cmd in env.get_walkthrough():
         obs, rew, done, info = env.step(cmd)
 
     if not done:


### PR DESCRIPTION
This PR adds the `seed` method to `FrotzEnv` that allows changing seed without creating a new instance of `FrotzEnv`.

NB: the default seed is the one from the bindings (i.e. the walkthrough) if it exists. Otherwise, the value -1 is used.