### PR TITLE
Add load(story_file) method to FrotzEnv

### DIFF
--- a/frotz/src/common/setup.h
+++ b/frotz/src/common/setup.h
@@ -30,6 +30,8 @@ typedef struct frotz_setup_struct {
         char *aux_name;
         char *story_path;
         char *zcode_path;
+        void *story_rom;
+		size_t story_rom_size;
 	char *restricted_path;
 	int restore_mode; /* for a save file passed from command line*/
 

--- a/frotz/src/dumb/dumb_init.c
+++ b/frotz/src/dumb/dumb_init.c
@@ -240,6 +240,13 @@ void load_story(char *s)
     strncat(f_setup.command_name, EXT_COMMAND, strlen(EXT_COMMAND));
 }
 
+void load_story_rom(char *s, void *buf, size_t size)
+{
+    load_story(s);
+    f_setup.story_rom = buf;
+    f_setup.story_rom_size = size;
+}
+
 void os_init_screen(void)
 {
     if (h_version == V3 && user_tandy_bit)
@@ -301,7 +308,12 @@ FILE *os_load_story(void)
 	  break;
     }
 
-    fp = fopen(f_setup.story_file, "rb");
+    if (f_setup.story_rom) {
+        fp = fmemopen(f_setup.story_rom, f_setup.story_rom_size, "rb");
+    }
+    else {
+        fp = fopen(f_setup.story_file, "rb");
+    }
 
     /* Is this a Blorb file containing Zcode? */
     if (f_setup.exec_in_blorb)

--- a/frotz/src/interface/frotz_interface.c
+++ b/frotz/src/interface/frotz_interface.c
@@ -38,6 +38,7 @@ extern char* dumb_get_screen(void);
 extern void dumb_clear_screen(void);
 extern void z_save (void);
 extern void load_story(char *s);
+extern void load_story_rom(char *s, void* rom, size_t rom_size);
 extern zword save_quetzal (FILE *, FILE *);
 extern zword restore_quetzal (FILE *, FILE *);
 extern int restore_undo (void);
@@ -1441,13 +1442,18 @@ void update_ram_diff() {
   }
 }
 
-char* setup(char *story_file, int seed) {
+char* setup(char *story_file, int seed, void *rom, size_t rom_size) {
   char* text;
   emulator_halted = 0;
   os_init_setup();
   desired_seed = seed;
   set_random_seed(desired_seed);
-  load_story(story_file);
+  if (rom) {
+    load_story_rom(story_file, rom, rom_size);
+  }
+  else {
+    load_story(story_file);
+  }
   init_buffer();
   init_err();
   init_memory();

--- a/frotz/src/interface/frotz_interface.h
+++ b/frotz/src/interface/frotz_interface.h
@@ -30,7 +30,7 @@ typedef struct {
   unsigned char properties[16];
 } zobject;
 
-extern char* setup(char *story_file, int seed);
+extern char* setup(char *story_file, int seed, void* rom, size_t rom_size);
 
 extern void shutdown();
 

--- a/tests/benchmarks.py
+++ b/tests/benchmarks.py
@@ -1,0 +1,38 @@
+import os
+import time
+from os.path import join as pjoin
+
+import jericho
+
+
+DATA_PATH = os.path.abspath(pjoin(__file__, '..', "data"))
+
+
+def bench_loading_speed():
+    REPEAT = 1000
+
+    start = time.time()
+    rom = pjoin(DATA_PATH, "905.z5")
+    for _ in range(REPEAT):
+        env = jericho.FrotzEnv(rom)
+        env.reset()
+        env.close()
+
+    duration1 = time.time() - start
+    print("Calling FrotzEnv({}) {} times in {:6.2f} secs.".format(rom, REPEAT, duration1))
+    del env
+
+    start = time.time()
+    env = jericho.FrotzEnv(rom)
+    for _ in range(REPEAT - 1):
+        env.load(rom)
+        env.reset()
+        env.close()
+
+    duration2 = time.time() - start
+    print("Calling env.load({}) {} times in {:6.2f} secs.".format(rom, REPEAT, duration2))
+    print("Speedup: {}x.".format(duration1 / duration2))
+
+
+if __name__ == "__main__":
+    bench_loading_speed()


### PR DESCRIPTION
This PR adds support to load a new story file without having to recreate a new FrotzEnv instance, thus avoiding creating and loading copies of `libfrotz.so`. That feature helps reduce the overhead of loading different games numerous times (e.g. meta-learning across different games). 

This PR also adds support to load a story file from memory in `libfrotz.so`.

Running `tests/benchmark.py` on my laptop I get a speedup of ~5.8x.
```
Calling FrotzEnv(905.z5) 1000 times in 6.71 secs.
Calling env.load(905.z5) 1000 times in 1.15 secs.
```