### PR TITLE
Fix frotz/dumb linker error: resolves #44

### DIFF
--- a/frotz/src/dumb/dumb_blorb.c
+++ b/frotz/src/dumb/dumb_blorb.c
@@ -30,7 +30,7 @@
 #include "dumb_frotz.h"
 #include "dumb_blorb.h"
 
-f_setup_t f_setup;
+extern f_setup_t f_setup;
 
 FILE *blorb_fp;
 bb_result_t blorb_res;

--- a/frotz/src/dumb/dumb_frotz.h
+++ b/frotz/src/dumb/dumb_frotz.h
@@ -20,7 +20,7 @@
 /* from ../common/setup.h */
 extern f_setup_t f_setup;
 
-bool do_more_prompts;
+extern bool do_more_prompts;
 
 /* From input.c.  */
 bool is_terminator (zchar);

--- a/frotz/src/dumb/dumb_init.c
+++ b/frotz/src/dumb/dumb_init.c
@@ -23,7 +23,7 @@
 #include "dumb_frotz.h"
 #include "dumb_blorb.h"
 
-f_setup_t f_setup;
+extern f_setup_t f_setup;
 
 static char *my_strdup(char *);
 static void print_version(void);
@@ -90,6 +90,8 @@ static bool plain_ascii = FALSE;
 void set_random_seed(int seed) {
   user_random_seed = seed;
 }
+
+bool do_more_prompts;
 
 void os_process_arguments(int argc, char *argv[])
 {

--- a/frotz/src/dumb/dumb_init.c
+++ b/frotz/src/dumb/dumb_init.c
@@ -23,7 +23,7 @@
 #include "dumb_frotz.h"
 #include "dumb_blorb.h"
 
-extern f_setup_t f_setup;
+f_setup_t f_setup;
 
 static char *my_strdup(char *);
 static void print_version(void);

--- a/frotz/src/dumb/dumb_input.c
+++ b/frotz/src/dumb/dumb_input.c
@@ -21,7 +21,7 @@
 
 #include "dumb_frotz.h"
 
-f_setup_t f_setup;
+extern f_setup_t f_setup;
 
 static char runtime_usage[] =
   "DUMB-FROTZ runtime help:\n"

--- a/frotz/src/dumb/dumb_output.c
+++ b/frotz/src/dumb/dumb_output.c
@@ -21,7 +21,7 @@
 
 #include "dumb_frotz.h"
 
-f_setup_t f_setup;
+extern f_setup_t f_setup;
 
 static bool show_line_numbers = FALSE;
 static bool show_line_types = -1;

--- a/frotz/src/dumb/dumb_pic.c
+++ b/frotz/src/dumb/dumb_pic.c
@@ -21,7 +21,7 @@
 
 #include "dumb_frotz.h"
 
-f_setup_t f_setup;
+extern f_setup_t f_setup;
 
 #define PIC_FILE_HEADER_FLAGS 1
 #define PIC_FILE_HEADER_NUM_IMAGES 4


### PR DESCRIPTION
- This commit adds necessary `extern` declarations to variable names to
avoid a linker error on modern gcc compilers. Update follows changes in
the update frotz library
(https://gitlab.com/DavidGriffith/frotz/-/tree/master/src/dumb)