### PR TITLE
FIX: read a short value (instead of char) for the score in dragon.z5

### DIFF
--- a/frotz/src/games/dragon.c
+++ b/frotz/src/games/dragon.c
@@ -74,7 +74,7 @@ int dragon_get_moves() {
 }
 
 short dragon_get_score() {
-  return (char) zmp[13451]; // 13475, 13477
+  return (((short) zmp[13450]) << 8) | zmp[13451]; // 13475, 13477
 }
 
 int dragon_max_score() {


### PR DESCRIPTION
This PR fixes issue #55 (at least for `dragon.z5`)

Here's the graph showing that underflow is still happening but after a lot of steps (16386)
![dragon_score_underflow](https://user-images.githubusercontent.com/660004/143911252-b6f23e38-9b64-4a84-a0aa-1721364d174c.png)
.
