### PR TITLE
Fix type errors against compiler errors

### DIFF
--- a/frotz/src/interface/frotz_interface.c
+++ b/frotz/src/interface/frotz_interface.c
@@ -466,7 +466,7 @@ void setZArgs(unsigned char *s) {
 //   Function pointers      //
 //==========================//
 
-char** (*ram_addr_fns[]) (int* num_actions) = {
+zword* (*ram_addr_fns[]) (int* num_actions) = {
   default_ram_addrs,
   acorn_ram_addrs,
   adventureland_ram_addrs,

--- a/frotz/src/ztools/infodump.c
+++ b/frotz/src/ztools/infodump.c
@@ -207,8 +207,8 @@ extern const char *optarg;
 
 #ifdef __STDC__
 void configure_inform_tables
-    (unsigned long, unsigned short, unsigned long, unsigned long, unsigned long,
-     unsigned long, unsigned long, unsigned long);
+    (unsigned long, unsigned short *, unsigned long *, unsigned long *, unsigned long *,
+     unsigned long *, unsigned long *, unsigned long *);
 #else
 void configure_inform_tables ();
 #endif

--- a/frotz/src/ztools/showobj.c
+++ b/frotz/src/ztools/showobj.c
@@ -19,8 +19,8 @@ static void print_object
 static void print_object_desc
     (int);
 void configure_inform_tables
-    (unsigned long, unsigned short, unsigned long, unsigned long, unsigned long,
-     unsigned long, unsigned long, unsigned long);
+    (unsigned long, unsigned short *, unsigned long *, unsigned long *, unsigned long *,
+     unsigned long *, unsigned long *, unsigned long *);
 int print_attribute_name (unsigned long, int);
 int print_property_name (unsigned long, int);
 #else

--- a/frotz/src/ztools/showverb.c
+++ b/frotz/src/ztools/showverb.c
@@ -21,8 +21,8 @@ static void show_words
 static unsigned long lookup_word
     (unsigned long, unsigned int, unsigned int, unsigned int);
 void configure_inform_tables
-    (unsigned long, unsigned short, unsigned long, unsigned long, unsigned long,
-     unsigned long, unsigned long, unsigned long);
+    (unsigned long, unsigned short *, unsigned long *, unsigned long *, unsigned long *,
+     unsigned long *, unsigned long *, unsigned long *);
 int print_attribute_name (unsigned long, int);
 int print_inform_action_name (unsigned long, int);
 void configure_object_tables
@@ -525,7 +525,7 @@ int symbolic;
 
     unsigned int obj_count;
     unsigned long obj_table_base, obj_table_end, obj_data_base, obj_data_end;
-    unsigned int inform_version;
+    unsigned short inform_version;
     unsigned long class_numbers_base, class_numbers_end;
     unsigned long property_names_base, property_names_end;
     unsigned long attr_names_base, attr_names_end;

--- a/frotz/src/ztools/tx.h
+++ b/frotz/src/ztools/tx.h
@@ -380,7 +380,7 @@ extern int property_size_mask;
 
 extern zbyte_t *datap;
 
-extern option_inform;
+extern short option_inform;
 
 extern unsigned long file_size;
 
@@ -431,7 +431,7 @@ void show_syntax_of_action(int action,
 			unsigned int prep_type,
 			unsigned long attr_names_base,
 			unsigned long prep_table_base);
-			
+
 void show_syntax_of_parsing_routine(unsigned long parsing_routine,
 				    unsigned long verb_table_base,
 				    unsigned int verb_count,
@@ -439,7 +439,7 @@ void show_syntax_of_parsing_routine(unsigned long parsing_routine,
 				    unsigned int prep_type,
 				    unsigned long prep_table_base,
 				    unsigned long attr_names_base);
-				    
+
 int is_gv2_parsing_routine(unsigned long parsing_routine,
 				    unsigned long verb_table_base,
 				    unsigned int verb_count);

--- a/frotz/src/ztools/txd.c
+++ b/frotz/src/ztools/txd.c
@@ -98,8 +98,8 @@ static void dump_opcode (unsigned long, int, int, int *, int);
 static void dump_operand (unsigned long *, int, int, int *, int *);
 static void print_variable (int);
 void configure_inform_tables
-    (unsigned long, unsigned short, unsigned long, unsigned long, unsigned long,
-     unsigned long, unsigned long, unsigned long);
+    (unsigned long, unsigned short *, unsigned long *, unsigned long *, unsigned long *,
+     unsigned long *, unsigned long *, unsigned long *);
 void configure_object_tables
     (unsigned int *, unsigned long *, unsigned long *, unsigned long *,
      unsigned long *);

--- a/frotz/src/ztools/txio.c
+++ b/frotz/src/ztools/txio.c
@@ -24,7 +24,7 @@ int property_size_mask;
 
 zbyte_t *datap;
 
-int option_inform = 0;
+short option_inform = 0;
 
 unsigned long file_size = 0;
 
@@ -406,7 +406,7 @@ unsigned long *address;
                         lookup_table[i][j] = v1_lookup_table[i][j];
                     else
                         lookup_table[i][j] = v3_lookup_table[i][j];
-                }   
+                }
                 if (option_inform && lookup_table[i][j] == '\"')
                     lookup_table[i][j] = '~';
             }
@@ -646,7 +646,7 @@ char *buf
                         lookup_table[i][j] = v1_lookup_table[i][j];
                     else
                         lookup_table[i][j] = v3_lookup_table[i][j];
-                }   
+                }
                 if (option_inform && lookup_table[i][j] == '\"')
                     lookup_table[i][j] = '~';
             }
@@ -992,7 +992,7 @@ int c;
     static int unicode_table_loaded;
     int unicode_table_addr;
     int length, i;
-    
+
     if (!unicode_table_loaded) {
     	if (header.mouse_table && (get_word(header.mouse_table) > 2)) {
 	    unicode_table_addr = get_word(header.mouse_table + 6);
@@ -1004,7 +1004,7 @@ int c;
 	}
 	unicode_table_loaded = 1;
     }
-  
+
     if ((c <= 0xdf) && !unicode_table[c]) {
     	if (option_inform)
 	    tx_printf("@%s", inform_euro_substitute[c - 0x9b]);


### PR DESCRIPTION
Problem: The code can't build with modern versions of gcc and clang
due to compiler errors (e.g., especially on arm64 macOS).

Mainly there are three issues:

- error: type specifier missing, defaults to 'int';
  ISO C99 and later do not support implicit int [-Wimplicit-int]

- error: incompatible pointer to integer conversion passing
  `'unsigned short *'` to parameter of type `'unsigned short'`;
  remove & [-Wint-conversion]

- error: incompatible function pointer types initializing
  `'char **(*)(int *)'` with an expression of type `'zword *(int *)'`
  (aka `'unsigned short *(int *)'`) [-Wincompatible-function-pointer-types]

Solution:

- Fix obvious mistakes in the function declaration.
- Use the correct type.
